### PR TITLE
Use correct date format pattern according to spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "bluebird": "^2.9.30",
     "csv": "^0.4.2",
-    "moment": "^2.10.3",
+    "d3-time-format": "^0.3.2",
+    "moment": "^2.13.0",
     "superagent": "^1.2.0",
     "underscore": "^1.8.3"
   },

--- a/test/types.js
+++ b/test/types.js
@@ -148,7 +148,7 @@ describe('DateType', function() {
   });
 
   it('cast date with format specified', function(done, err) {
-    BASE_FIELD.format = 'fmt:DD/MM/YYYY';
+    BASE_FIELD.format = 'fmt:%d/%m/%Y';
     assert((new types.DateType(BASE_FIELD)).cast('10/06/2014'));
     done();
   });
@@ -164,7 +164,7 @@ describe('DateType', function() {
   });
 
   it('don\'t cast date if it do not correspond specified format', function(done, err) {
-    BASE_FIELD.format = 'fmt:DD/MM/YYYY';
+    BASE_FIELD.format = 'fmt:%d/%m/%Y';
     assert.notOk((new types.DateType(BASE_FIELD)).cast('2014/12/19'));
     done();
   });

--- a/types.js
+++ b/types.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var moment = require('moment');
+var d3time = require('d3-time-format');
 var utilities = require('./utilities');
 
 
@@ -320,7 +321,6 @@ module.exports.DateType.prototype = _.extend(module.exports.DateType.prototype, 
 
     if(date.isValid())
       return date;
-
     return false;
   },
 
@@ -343,12 +343,12 @@ module.exports.DateType.prototype = _.extend(module.exports.DateType.prototype, 
     var date;
 
     try {
-      date = moment(value, this.format.replace(/^fmt:/, ''), true);
+      date = d3time.timeParse(this.format.replace(/^fmt:/, ''))(value);
     } catch(E) {
       return false;
     }
 
-    if(date.isValid())
+    if(date != null)
       return date;
 
     return false;


### PR DESCRIPTION
Moment.js does not support the percent-notation for time formats.
The simplest solution I found was to add the d3-time-parser module, and use it for the specific case where format is specified. Moment is still far better in deducing dates from general strings, and it would be a shame to lose that functionality.
